### PR TITLE
To yaml fix

### DIFF
--- a/src/basic-widget.ts
+++ b/src/basic-widget.ts
@@ -1,0 +1,22 @@
+import { Widget } from '@tinystacks/ops-model';
+import { BaseProvider } from './base-provider';
+import { BaseWidget } from './base-widget';
+import { OtherProperties } from './types';
+
+class BasicWidget extends BaseWidget {
+  constructor (props: Widget & OtherProperties) {
+    super(props);
+  }
+  getData (_providers?: BaseProvider[], _overrides?: any): void | Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  render (_children?: (Widget & { renderedElement: JSX.Element; })[], _overridesCallback?: (overrides: any) => void): JSX.Element {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export {
+  BasicWidget
+};
+
+export default BasicWidget;

--- a/src/console-parser.ts
+++ b/src/console-parser.ts
@@ -166,10 +166,10 @@ export class ConsoleParser implements Console {
     delete this.widgets[id];
   }
 
-  async toYaml (): Promise<ExportConsoleYaml> {
+  toYaml (): ExportConsoleYaml {
     const dashboardObjects: { [id: string]: Dashboard } = {};
     for (const [id, dashboard] of Object.entries(this.dashboards)) {
-      dashboardObjects[id] = DashboardParser.toYaml(dashboard);
+      dashboardObjects[id] = dashboard.toYaml();
     }
     
     const providerObjects: { [id: string]: YamlProvider } = {};

--- a/src/dashboard-parser.ts
+++ b/src/dashboard-parser.ts
@@ -62,18 +62,13 @@ export class DashboardParser implements Dashboard {
     };
   }
 
-  static toYaml (dashboard: Dashboard) {
-    const { 
-      route, 
-      widgetIds,
-      id
-    } = dashboard;
+  toYaml () {
     // TODO: This is cheap and restrictive, we should store the original ref on the widget and use that here.
-    const widgets = widgetIds.map(widgetId => ({ $ref: `#/Console/widgets/${widgetId}` }));
+    const widgets =this. widgetIds.map(widgetId => ({ $ref: `#/Console/widgets/${widgetId}` }));
     return {
-      route,
+      route: this.route,
       widgets,
-      id 
+      id: this.id
     };
   }
 

--- a/src/dashboard-parser.ts
+++ b/src/dashboard-parser.ts
@@ -64,7 +64,7 @@ export class DashboardParser implements Dashboard {
 
   toYaml () {
     // TODO: This is cheap and restrictive, we should store the original ref on the widget and use that here.
-    const widgets =this. widgetIds.map(widgetId => ({ $ref: `#/Console/widgets/${widgetId}` }));
+    const widgets = this.widgetIds.map(widgetId => ({ $ref: `#/Console/widgets/${widgetId}` }));
     return {
       route: this.route,
       widgets,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,7 @@
+type OtherProperties = {
+  [key: string]: any
+};
+
+export {
+  OtherProperties
+};


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix


## Summary of Bug Fix
Previously, ConsoleParser.toYaml was losing any widget data not present on BaseWidget.

Now we utilize Widget<T>.toJson to retain these properties, and a merge of Widget<T>.toJson with BaseWidget.toJson via a new proxy class BasicWidget to ensure all base properties from BaseWidget are included.  This is primarily to safeguard against Widget<T>.toJson implementations that do no call super.toJson 

Other updates:

- ConsoleParser.toYaml is no longer static because it has no need to be.
- ConsoleParser.toYaml is no longer async because it has no need to be.
- Dashboard.toYaml is no longer static because it has no need to be.
- Dashboard.toYaml is no longer async because it has no need to be.